### PR TITLE
Return only the body of the response or the error reason

### DIFF
--- a/lib/voodoo/util.ex
+++ b/lib/voodoo/util.ex
@@ -5,10 +5,9 @@ defmodule Voodoo.Util do
 
   # process voodoo response
   def handle_voodoo_response(res) do
-    cond do
-      res["error"] -> {:error, res}
-      res["data"] -> {:ok, res}
-      true -> {:ok, res}
+    case res do
+      {:error, error} -> {:error, error.reason}
+      {:ok, res} -> {:ok, res.body}
     end
   end
 end


### PR DESCRIPTION
@samcorcos is this what you intended? The error we were getting was because of `res["error"]`. `[]` doesn't work on tuples.
